### PR TITLE
Adjusted several CSS elements to make the banner responsive on larger and smaller screens

### DIFF
--- a/public/Tempest.css
+++ b/public/Tempest.css
@@ -2598,7 +2598,7 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 531px) {
   .ssconf__media-container {
     width: 300px;
     height: 300px;
@@ -2756,7 +2756,7 @@
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 531px) {
   .aca__media-container {
     width: 300px;
     height: 300px;


### PR DESCRIPTION
Previously the countdown display in the banner section was not in the correct position when using a larger screen scale
Before :
![image](https://github.com/user-attachments/assets/0677e739-6e91-4edc-a51a-633f312469b7)

After : 
![image](https://github.com/user-attachments/assets/c6f44d9f-5978-400a-b682-8a297f69bc88)